### PR TITLE
Update Dockerfile.mingw

### DIFF
--- a/Dockerfile.mingw
+++ b/Dockerfile.mingw
@@ -106,6 +106,6 @@ RUN tar xf libssh2-1.9.0.tar.gz && \
         LIBS="-lws2_32" && \
     make install
 ADD https://api.github.com/repos/aria2/aria2/git/refs/heads/master version.json
-RUN git clone https://github.com/aria2/aria2 && \
+RUN git clone https://github.com/aliemjay/aria2.git && \
     cd aria2 && autoreconf -i && ./mingw-config && make && \
     $HOST-strip src/aria2c.exe

--- a/Dockerfile.mingw
+++ b/Dockerfile.mingw
@@ -11,7 +11,7 @@
 # $ sudo docker cp $id:/aria2/src/aria2c.exe <dest>
 # $ sudo docker rm -v $id
 
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 MAINTAINER Tatsuhiro Tsujikawa
 
@@ -26,7 +26,7 @@ RUN apt-get update && \
     apt-get install -y \
         make binutils autoconf automake autotools-dev libtool \
         pkg-config git curl dpkg-dev gcc-mingw-w64 g++-mingw-w64 \
-        autopoint libcppunit-dev libxml2-dev libgcrypt11-dev lzip
+        autopoint libcppunit-dev libxml2-dev lzip
 
 RUN curl -L -O https://gmplib.org/download/gmp/gmp-6.1.2.tar.lz && \
     curl -L -O https://github.com/libexpat/libexpat/releases/download/R_2_2_7/expat-2.2.7.tar.bz2 && \


### PR DESCRIPTION
Update to supported yet Eoan Ermine, no need for libgcrypt on Windows (Schannel).